### PR TITLE
create local version compatible with pep-0440

### DIFF
--- a/lib/ansible/__init__.py
+++ b/lib/ansible/__init__.py
@@ -14,5 +14,5 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-__version__ = '1.9.5'
+__version__ = '1.9.5+datarobot-0'
 __author__ = 'Ansible, Inc.'


### PR DESCRIPTION
##### SUMMARY
- Publish 1.9.5+datarobot.0 to artifactory. This has a "local version" segment ("+datarobot") compatible with PEP-0440 as used by pip.

http://artifactory.int.datarobot.com/artifactory/webapp/#/artifacts/browse/simple/General/datarobot-python-legacy/ansible/1.9.5+datarobot.0/ansible-1.9.5+datarobot.0.tar.gz
##### ANSIBLE VERSION

From: `pip install ansible==1.9.5+datarobot.0`

```
ansible 1.9.5+datarobot-0
  configured module search path = None
```

@alex-dr 
