### PR TITLE
bump version to reflect package with modules

### DIFF
--- a/lib/ansible/__init__.py
+++ b/lib/ansible/__init__.py
@@ -14,5 +14,5 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-__version__ = '1.9.5+datarobot-0'
+__version__ = '1.9.5+datarobot-1'
 __author__ = 'Ansible, Inc.'


### PR DESCRIPTION
#### ANSIBLE VERSION

`1.9.5+datarobot.1`
#### SUMMARY

Did not do a submodule update with `1.9.5+datarobot.0`, meaning did not have core or updated modules. Have pushed `1.9.5+datarobot.1` to artifactory with submodules, so working, with SELinux backports.

@alex-dr @datarobot/release 
